### PR TITLE
refactor: Refactor server start method.

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -57,12 +57,9 @@ export default class Server {
     }
 
     async start() {
-        return new Promise<void>((res, rej) => {
-            this.app.listen(this.port, () => {
-                this.app.printEndpoints();
-                log.info(`Server is listening on port ${this.port}`);
-                res();
-            });
+        this.app.listen(this.port, () => {
+            this.app.printEndpoints();
+            log.info(`Server is listening on port ${this.port}`);
         });
     }
 }


### PR DESCRIPTION
There is no need to return a new Promise if async keyword assigned. 

> Async functions always return a promise. If the return value of an async function is not explicitly a promise, it will be implicitly wrapped in a promise.

[Reference - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#description)